### PR TITLE
feat: add POST /api/quotes endpoint to create new quotes

### DIFF
--- a/backend/src/main/java/com/nikhil/Quoteverse/QuoteController.java
+++ b/backend/src/main/java/com/nikhil/Quoteverse/QuoteController.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.*;
 
 @CrossOrigin(origins = "http://localhost:5173")
 @RestController
@@ -38,7 +39,8 @@ public class QuoteController {
 
             return ResponseEntity.ok(quotes);
 
-        } catch (IOException e) {
+        } 
+        catch (IOException e) {
             return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
         }
     }
@@ -72,7 +74,46 @@ public class QuoteController {
 
             return ResponseEntity.status(404).body(Map.of("message", "Quote not found"));
 
-        } catch (IOException e) {
+        } 
+        catch (IOException e) {
+            return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+
+    @PostMapping("/quotes")
+    public ResponseEntity<?> addQuote(@RequestBody Map<String, Object> newQuoteData) {
+        try {
+            String basePath = System.getProperty("user.dir");
+            Path filePath = Path.of(basePath)
+                .resolve("QuoteVerse")
+                .resolve("data")
+                .resolve("quotes.json")
+                .normalize();
+
+            File file = filePath.toFile();
+
+            if (!file.exists()) {
+                return ResponseEntity.status(404)
+                        .body(Map.of("error", "quotes.json not found at " + file.getAbsolutePath()));
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            List<Map<String, Object>> quotes = mapper.readValue(file, new TypeReference<List<Map<String, Object>>>() {});
+            int newId = quotes.stream()
+                    .mapToInt(q -> ((Number) q.get("id")).intValue())
+                    .max()
+                    .orElse(0) + 1;
+            Map<String, Object> newQuote = new LinkedHashMap<>();
+            newQuote.put("id", newId);
+            newQuote.put("text", newQuoteData.get("text"));
+            newQuote.put("author", newQuoteData.get("author"));
+            newQuote.put("tags", newQuoteData.getOrDefault("tags", List.of()));
+            quotes.add(newQuote);
+            mapper.writerWithDefaultPrettyPrinter().writeValue(file, quotes);
+            return ResponseEntity.ok(newQuote);
+        } 
+        catch (IOException e) {
             return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
         }
     }


### PR DESCRIPTION
# Pull Request Checklist
fixes #3 
This pull request adds a new POST /api/quotes endpoint to allow users to create new quotes.
The endpoint accepts a JSON body containing the quote text, author, and optional tags, and returns the created quote object as a response.

- [x] My PR has a clear title and description of changes.
- [x] I followed the contribution guide in `CONTRIBUTING.md`.
- [x] I added/updated documentation where necessary.
- [x] I tested the project locally (basic smoke test).

Changes Made:
Added POST mapping in QuoteController.java
Implemented request body parsing for Quote objects
Added response handling for successful quote creation

